### PR TITLE
Added Rule#from

### DIFF
--- a/lib/rrule/rule.rb
+++ b/lib/rrule/rule.rb
@@ -26,6 +26,11 @@ module RRule
       all_until(start_date: floored_start_date, end_date: floored_end_date, limit: limit).reject { |instance| instance < floored_start_date }
     end
 
+    def from(start_date, limit:)
+      floored_start_date = floor_to_seconds_in_timezone(start_date)
+      all_until(start_date: floored_start_date, limit: limit).reject { |instance| instance < floored_start_date }
+    end
+
     def each(floor_date: nil)
       # If we have a COUNT or INTERVAL option, we have to start at dtstart, because those are relative to dtstart
       floor_date = dtstart if count_or_interval_present? || floor_date.nil? || dtstart > floor_date

--- a/spec/rule_spec.rb
+++ b/spec/rule_spec.rb
@@ -2298,6 +2298,43 @@ describe RRule::Rule do
     end
   end
 
+  describe '#from' do
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = Time.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.from(Time.parse('Sun, 08 Apr 2018 00:00:00 +0000'), limit: 9))
+        .to match_array([
+        Time.parse('Sun, 08 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 15 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 22 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 29 Apr 2018 23:59:59 +1000'),
+        Time.parse('Sun, 06 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 27 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 03 Jun 2018 23:59:59 +1000'),
+      ])
+    end
+
+    it 'returns the correct result with an rrule of FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU starting beyond the beginning of the result' do
+      rrule = 'FREQ=WEEKLY;BYSECOND=59;BYMINUTE=59;BYHOUR=23;WKST=SU'
+      dtstart = Time.parse('2018-02-04 04:00:00 +1000')
+      timezone = 'Brisbane'
+
+      rrule = RRule::Rule.new(rrule, dtstart: dtstart, tzid: timezone)
+      expect(rrule.from(Time.parse('Sun, 13 May 2018 23:59:59 +1000'), limit: 4))
+        .to match_array([
+        Time.parse('Sun, 13 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 20 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 27 May 2018 23:59:59 +1000'),
+        Time.parse('Sun, 03 Jun 2018 23:59:59 +1000'),
+      ])
+    end
+  end
+
   it 'returns the correct result with an rrule of FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2' do
     rrule = 'FREQ=WEEKLY;BYMONTH=1,3;COUNT=4;BYHOUR=2'
     dtstart = Time.parse('Tue Sep  2 09:00:00 PDT 1997')


### PR DESCRIPTION
`Rule#between` requires one to pick a reasonable `end_date`, which is
sometimes inconvenient. `Rule#from` requires a `limit` but not an
`end_date`.